### PR TITLE
Schwellwert abschalten angepasst

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -176,7 +176,7 @@ bool switch_pin(uint8_t pin) {
     double input_sum = std::accumulate(input_power_history.begin(), input_power_history.end(), 0);
     int mean_input = (int) (input_sum / input_power_history.size());
     if (is_pin0_on) {
-        is_on = (min_battery >= settings_battery_charge) && (mean_input >= 0);
+        is_on = (min_battery >= settings_battery_charge) && (mean_input >= 100);
     } else {
         is_on = (min_battery >= settings_battery_charge) && (mean_input >= settings_input_power);
     }


### PR DESCRIPTION
Der Schwellwert welcher angeibt ob noch überschuss vorhanden ist wurde auf 100 Watt statt 0 Watt angepasst